### PR TITLE
Rettet feil i mock panel når det ikke er et utkast

### DIFF
--- a/src/mock/vedtak-mock.ts
+++ b/src/mock/vedtak-mock.ts
@@ -11,7 +11,7 @@ import { enhetId, enhetNavn } from './konstanter';
 import env from '../utils/environment';
 import { SkjemaData } from '../utils/skjema-utils';
 
-export let vedtakUtkastMock = env.isRunningOnGhPages ? null : utkast;
+export let vedtakUtkastMock: Vedtak | null = env.isRunningOnGhPages ? null : utkast;
 const fattedeVedtak = historisk;
 
 export const mockHentUtkast: Mock = {
@@ -76,7 +76,10 @@ export const mockOppdaterUtkast: Mock = {
 
 export const oppdaterVedtakUtkastMockFraSkjema = (skjemaData: SkjemaData) => {
 	if (vedtakUtkastMock) {
-		vedtakUtkastMock = Object.assign(vedtakUtkastMock || {}, skjemaData) as Vedtak;
+		vedtakUtkastMock.begrunnelse = skjemaData.begrunnelse;
+		vedtakUtkastMock.hovedmal = skjemaData.hovedmal;
+		vedtakUtkastMock.innsatsgruppe = skjemaData.innsatsgruppe;
+		vedtakUtkastMock.opplysninger = skjemaData.opplysninger ? skjemaData.opplysninger : [];
 	}
 };
 

--- a/src/mock/vedtak-mock.ts
+++ b/src/mock/vedtak-mock.ts
@@ -75,7 +75,9 @@ export const mockOppdaterUtkast: Mock = {
 };
 
 export const oppdaterVedtakUtkastMockFraSkjema = (skjemaData: SkjemaData) => {
-	vedtakUtkastMock = Object.assign(vedtakUtkastMock || {}, skjemaData) as Vedtak;
+	if (vedtakUtkastMock) {
+		vedtakUtkastMock = Object.assign(vedtakUtkastMock || {}, skjemaData) as Vedtak;
+	}
 };
 
 export const mockSlettUtkast: Mock = {


### PR DESCRIPTION
Når man bytter bruker i mock panel og det ikke er et utkast, så skal utkastet forbli null