### PR TITLE
Fjerne legeerklæring som et eksempel på kilder ved opprettelse av vedtak

### DIFF
--- a/src/page/utkast/skjema-section/kilder/kilder-tips-innhold.tsx
+++ b/src/page/utkast/skjema-section/kilder/kilder-tips-innhold.tsx
@@ -22,7 +22,6 @@ export const KilderTipsInnhold = () => {
 					<br />
 					1. september 20xx
 				</li>
-				<li>Legeerklæringen 1. november 20xx</li>
 			</ul>
 		</>
 	);


### PR DESCRIPTION
Fjernet linje som legeerklæring: Legeerklæringen 1. november 20xx

![Screenshot 2023-04-25 at 13 17 38](https://user-images.githubusercontent.com/3892999/234260948-96dad49d-78e2-45f3-b21d-fdc738b001c6.png)
