### PR TITLE
Endring i situasjon inn i tekst for registrering som kilde

### DIFF
--- a/src/mock/api-data.ts
+++ b/src/mock/api-data.ts
@@ -123,7 +123,7 @@ const historisk: Vedtak[] = [
 			'- listepunkt 4\n' +
 			'- listepunkt 5',
 		opplysninger: [
-			'Svarene dine fra da du registrerte deg',
+			'Svarene dine fra da du registrerte deg og informasjonen du har gitt om endringer i jobbsituasjonen din',
 			'CV-en/jobbprofilen din på nav.no',
 			'Svarene dine om behov for veiledning'
 		],
@@ -140,7 +140,7 @@ const historisk: Vedtak[] = [
 		hovedmal: HovedmalType.SKAFFE_ARBEID,
 		innsatsgruppe: InnsatsgruppeType.STANDARD_INNSATS,
 		opplysninger: [
-			'Svarene dine fra da du registrerte deg',
+			'Svarene dine fra da du registrerte deg og informasjonen du har gitt om endringer i jobbsituasjonen din',
 			'Lorem ipsum dolor sit amet, consectetur adipiscing elit'
 		],
 		vedtakFattet: '2019-12-12T12:58:43.716393+02:00',

--- a/src/util/skjema-utils.ts
+++ b/src/util/skjema-utils.ts
@@ -14,7 +14,7 @@ export interface SkjemaData {
 }
 
 export const kildelisteBokmal = [
-	'Svarene dine fra da du registrerte deg',
+	'Svarene dine fra da du registrerte deg og informasjonen du har gitt om endringer i jobbsituasjonen din',
 	'CV-en/jobbprofilen din på nav.no',
 	'Svarene dine om behov for veiledning'
 ];


### PR DESCRIPTION
Endrer teksten til "registrering" som kilde for vedtak til å inneholde eventuelle endringer i jobb situasjonen bruker har gjort.
<img width="1238" alt="Screenshot 2023-06-30 at 14 31 34" src="https://github.com/navikt/veilarbvedtaksstottefs/assets/3892999/4f892467-08f5-4014-be08-c48ff52e0ddd">
