### PR TITLE
Ta i bruk nye veilarboppfolging-endepunkter uten fnr i URL

### DIFF
--- a/src/api/veilarboppfolging.ts
+++ b/src/api/veilarboppfolging.ts
@@ -9,9 +9,9 @@ export default interface OppfolgingData {
 }
 
 export function fetchOppfolging(fnr: string): AxiosPromise<OppfolgingData> {
-	return axiosInstance.get(`/veilarboppfolging/api/oppfolging?fnr=${fnr}`);
+	return axiosInstance.post(`/veilarboppfolging/api/v3/oppfolging/hent-status`, { fnr });
 }
 
 export function fetchTilgangTilBrukersKontor(fnr: string): AxiosPromise<TilgangTilBrukersKontor> {
-	return axiosInstance.get(`/veilarboppfolging/api/oppfolging/veilederTilgang?fnr=${fnr}`);
+	return axiosInstance.post(`/veilarboppfolging/api/v3/oppfolging/hent-veilederTilgang`, { fnr });
 }


### PR DESCRIPTION
- [x] Vent med å merge til https://github.com/navikt/veilarboppfolging/tree/nytt-api-uten-fnr er klar og merget