### PR TITLE
Hindre hovedmål skaffe arbeid hvis ikke aktiv arbeidssøkerperiode

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yaml
+++ b/.github/workflows/deploy-dev-gcp.yaml
@@ -22,8 +22,11 @@ jobs:
               with:
                   node-version: 20
                   cache: npm
+                  registry-url: "https://npm.pkg.github.com"
             - name: Install dependencies
               run: npm ci
+              env:
+                NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
             - name: Run tests
               run: npm run test
             - name: Build application

--- a/.github/workflows/deploy-prod-gcp.yaml
+++ b/.github/workflows/deploy-prod-gcp.yaml
@@ -22,8 +22,11 @@ jobs:
               with:
                   node-version: 20
                   cache: npm
+                  registry-url: "https://npm.pkg.github.com"
             - name: Install dependencies
               run: npm ci
+              env:
+                NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
             - name: Run tests
               run: npm run test
             - name: Build application

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ Intern applikasjon som brukes av veiledere for å opprette/sende 14A vedtak til 
 
 Testversjon av løsningen: [https://navikt.github.io/veilarbvedtaksstottefs](https://navikt.github.io/veilarbvedtaksstottefs)
 
+### Installere pakker
+
+For å kunne hente ned @navikt/arbeidssokerregisteret-utils må du legge til en `.npmrc` fil i homemappen med følgende innhold:
+
+shell
+//npm.pkg.github.com/:\_authToken=TOKEN
+@navikt:registry=https://npm.pkg.github.com
+[Se navikt/frontend](https://github.com/navikt/frontend?tab=readme-ov-file#installere-pakker-lokalt)
+
 ## Konfigurere git blame til å ignorere spesifikke commits
 
 Om du ønsker er det mulig å konfigurere git blame til å ignorere spesifikke commits definert i [.git-blame-ignore-revs](.git-blame-ignore-revs) (naviger til filen for å se hvilke commits som er ignorert for dette prosjektet).

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@craco/craco": "7.1.0",
         "@navikt/aksel-icons": "5.18.3",
+        "@navikt/arbeidssokerregisteret-utils": "0.22.0",
         "@navikt/ds-css": "5.18.3",
         "@navikt/ds-react": "5.18.3",
         "@navikt/fnrvalidator": "1.3.0",
@@ -3278,6 +3279,14 @@
       "version": "5.18.3",
       "resolved": "https://registry.npmjs.org/@navikt/aksel-icons/-/aksel-icons-5.18.3.tgz",
       "integrity": "sha512-kytq0BT1xsJBrG7/eyDuMQLddQZA4OMT3Fw3VLGHsJNqjEWEVOl3uYCGL70Thvg0+du0s/Z3mXPQUQpIaDt7rg=="
+    },
+    "node_modules/@navikt/arbeidssokerregisteret-utils": {
+      "version": "0.22.0",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/arbeidssokerregisteret-utils/0.22.0/6607346918b5e4edc317dcc6900cb27a2b9c1c0e",
+      "integrity": "sha512-pPhWQ14pgdMnBPMUnkAMqB+728xjj2Y1Sc3WFH+Nb9S45KP55gXBJmNp4l8WvMkN1TgvJVkdub1fHfQu7g56qg==",
+      "engines": {
+        "node": ">=20.11.0"
+      }
     },
     "node_modules/@navikt/ds-css": {
       "version": "5.18.3",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@craco/craco": "7.1.0",
     "@navikt/aksel-icons": "5.18.3",
+    "@navikt/arbeidssokerregisteret-utils": "0.22.0",
     "@navikt/ds-css": "5.18.3",
     "@navikt/ds-react": "5.18.3",
     "@navikt/fnrvalidator": "1.3.0",

--- a/src/api/veilarbperson.ts
+++ b/src/api/veilarbperson.ts
@@ -1,5 +1,6 @@
 import { AxiosPromise } from 'axios';
 import { axiosInstance } from './utils';
+import { ArbeidssokerPeriode } from '@navikt/arbeidssokerregisteret-utils';
 
 export enum MalformType {
 	nb = 'nb',
@@ -12,4 +13,8 @@ export interface MalformData {
 
 export function fetchMalform(fnr: string): AxiosPromise<MalformData> {
 	return axiosInstance.post(`/veilarbperson/api/v3/person/hent-malform`, { fnr });
+}
+
+export function fetchAktivArbeidssokerperiode(fnr: string): AxiosPromise<ArbeidssokerPeriode> {
+	return axiosInstance.post(`/veilarbperson/api/v3/person/hent-siste-aktiv-arbeidssoekerperiode`, { fnr });
 }

--- a/src/mock/api-data.ts
+++ b/src/mock/api-data.ts
@@ -11,6 +11,7 @@ import { SkjemaData } from '../util/skjema-utils';
 import env from '../util/environment';
 import { ArenaVedtak } from '../api/veilarbvedtaksstotte/vedtak';
 import { OyblikksbildeCv, OyblikksbildeEgenvurdering, OyblikksbildeRegistrering } from '../util/type/oyblikksbilde';
+import { ArbeidssokerPeriode } from '@navikt/arbeidssokerregisteret-utils';
 
 const tilgangTilBrukersKontor: TilgangTilBrukersKontor = {
 	tilgangTilBrukersKontor: true
@@ -25,6 +26,19 @@ const oppfolgingData: OppfolgingData = {
 const malformFraPdl: MalformData = {
 	malform: MalformType.nn
 };
+
+const arbeidssokerperiode = {
+	periodeId: 'periode-id-123',
+	startet: {
+		tidspunkt: '2020-01-01T12:00:00.000Z',
+		utfoertAv: {
+			type: 'SLUTTBRUKER'
+		},
+		kilde: '',
+		aarsak: ''
+	},
+	avsluttet: null
+} as unknown as ArbeidssokerPeriode;
 
 const features: FeatureToggles = {
 	[PRELANSERING_INFO_OM_LOSNING_TOGGLE]: true
@@ -222,6 +236,10 @@ export function hentOppfolgingData(): OppfolgingData {
 
 export function hentMalformFraPdl(): MalformData {
 	return malformFraPdl;
+}
+
+export function hentAktivArbeidssokerperiode(): ArbeidssokerPeriode {
+	return arbeidssokerperiode;
 }
 
 export function hentArenaVedtak(): ArenaVedtak[] {

--- a/src/mock/api/veilarbperson.ts
+++ b/src/mock/api/veilarbperson.ts
@@ -1,10 +1,14 @@
 import { delay, http, HttpResponse, RequestHandler } from 'msw';
-import { hentMalformFraPdl } from '../api-data';
+import { hentAktivArbeidssokerperiode, hentMalformFraPdl } from '../api-data';
 import { DEFAULT_DELAY_MILLISECONDS } from '../index';
 
 export const veilarbpersonHandlers: RequestHandler[] = [
 	http.post('/veilarbperson/api/v3/person/hent-malform', async () => {
 		await delay(DEFAULT_DELAY_MILLISECONDS);
 		return HttpResponse.json(hentMalformFraPdl());
+	}),
+	http.post('/veilarbperson/api/v3/person/hent-siste-aktiv-arbeidssoekerperiode', async () => {
+		await delay(DEFAULT_DELAY_MILLISECONDS);
+		return HttpResponse.json(hentAktivArbeidssokerperiode());
 	})
 ];

--- a/src/page/utkast/skjema-section/hovedmal/hovedmal.tsx
+++ b/src/page/utkast/skjema-section/hovedmal/hovedmal.tsx
@@ -53,10 +53,6 @@ interface HovedmalRadioButtonsProps {
 }
 
 function HovedmalRadioButtons(props: HovedmalRadioButtonsProps) {
-	const tilgjengeligeHovedmal = alleHovedmal.filter(mal =>
-		!props.arbeidssokerperiode && mal.value === HovedmalType.SKAFFE_ARBEID ? false : true
-	);
-
 	return (
 		<div className="hovedmal">
 			{!props.arbeidssokerperiode && (
@@ -64,7 +60,7 @@ function HovedmalRadioButtons(props: HovedmalRadioButtonsProps) {
 					Hovedmål <i>skaffe arbeid</i> kan ikke velges fordi personen ikke er registrert som arbeidssøker.
 				</Alert>
 			)}
-			{tilgjengeligeHovedmal.map((mal, idx) => (
+			{alleHovedmal.map((mal, idx) => (
 				<Radio
 					name="hovedmal"
 					key={idx}
@@ -73,6 +69,8 @@ function HovedmalRadioButtons(props: HovedmalRadioButtonsProps) {
 					onChange={(e: any) => props.handleHovedmalChanged(e.target.value)}
 					checked={props.hovedmal === mal.value}
 					onKeyPress={swallowEnterKeyPress}
+					// Hvis brukeren ikke har en aktiv arbeidssøkerperiode, skal ikke hovedmål "Skaffe arbeid" kunne velges
+					disabled={!props.arbeidssokerperiode && mal.value === HovedmalType.SKAFFE_ARBEID}
 				/>
 			))}
 		</div>


### PR DESCRIPTION
Arena skrur i kveld av muligheten til å velge *skaffe arbeid* hvis en bruker ikke har en aktiv arbeidssøkerperiode, fordi Paw blir master. For at vi (pilotkontoret) ikke skal havne i usynk, så må vi gjøre det samme.