### PR TITLE
Vis hovedmål i staden for gamle innsatsgruppenamn

### DIFF
--- a/src/component/panel/gjeldende-vedtak/gjeldende-vedtak-panel.tsx
+++ b/src/component/panel/gjeldende-vedtak/gjeldende-vedtak-panel.tsx
@@ -22,7 +22,7 @@ export function GjeldendeVedtakPanel(props: { gjeldendeVedtak: Vedtak }) {
 		<VedtaksstottePanel
 			tittel="Gjeldende oppfølgingsvedtak"
 			undertittel={innsatsgruppeData.tittel}
-			innsatsgruppe={innsatsgruppeData.undertekst}
+			detaljer={innsatsgruppeData.undertekst}
 			panelKlasse="gjeldende-vedtak-panel"
 			imgSrc={fullfortVedtakIcon}
 			tekstKomponent={

--- a/src/component/panel/gjeldende-vedtak/gjeldende-vedtak-panel.tsx
+++ b/src/component/panel/gjeldende-vedtak/gjeldende-vedtak-panel.tsx
@@ -1,3 +1,4 @@
+import { Button, Detail } from '@navikt/ds-react';
 import { VedtaksstottePanel } from '../vedtaksstotte/vedtaksstotte-panel';
 import { useViewStore, ViewType } from '../../../store/view-store';
 import { getInnsatsgruppeTekst } from '../../../util/innsatsgruppe';
@@ -5,13 +6,14 @@ import fullfortVedtakIcon from './fullfort.svg';
 import { logMetrikk } from '../../../util/logger';
 import { Vedtak } from '../../../api/veilarbvedtaksstotte';
 import { formatDateStr } from '../../../util/date-utils';
-import { Button, Detail } from '@navikt/ds-react';
+import { getHovedmalNavn } from '../../../util/hovedmal';
 import './gjeldende-vedtak-panel.css';
 
 export function GjeldendeVedtakPanel(props: { gjeldendeVedtak: Vedtak }) {
 	const { changeView } = useViewStore();
-	const { id, innsatsgruppe, veilederNavn, vedtakFattet } = props.gjeldendeVedtak;
+	const { id, innsatsgruppe, hovedmal, veilederNavn, vedtakFattet } = props.gjeldendeVedtak;
 	const innsatsgruppeData = getInnsatsgruppeTekst(innsatsgruppe);
+	const hovedmalTekst = hovedmal ? getHovedmalNavn(hovedmal) : undefined;
 
 	const handleVisVedtakClicked = () => {
 		changeView(ViewType.VEDTAK, { vedtakId: id });
@@ -22,7 +24,7 @@ export function GjeldendeVedtakPanel(props: { gjeldendeVedtak: Vedtak }) {
 		<VedtaksstottePanel
 			tittel="Gjeldende oppfølgingsvedtak"
 			undertittel={innsatsgruppeData.tittel}
-			detaljer={innsatsgruppeData.undertekst}
+			detaljer={hovedmalTekst}
 			panelKlasse="gjeldende-vedtak-panel"
 			imgSrc={fullfortVedtakIcon}
 			tekstKomponent={

--- a/src/component/panel/vedtaksstotte/vedtaksstotte-panel.tsx
+++ b/src/component/panel/vedtaksstotte/vedtaksstotte-panel.tsx
@@ -7,15 +7,22 @@ import './vedtaksstotte-panel.css';
 interface VedtaksstottePanelProps {
 	tittel: string;
 	undertittel: string;
-	innsatsgruppe?: string;
+	detaljer?: string;
 	imgSrc: string;
 	tekstKomponent: React.ReactNode;
 	knappKomponent?: React.ReactNode;
 	panelKlasse?: string;
 }
 
-export function VedtaksstottePanel(props: VedtaksstottePanelProps) {
-	const { tittel, undertittel, imgSrc, tekstKomponent, knappKomponent, panelKlasse, innsatsgruppe } = props;
+export function VedtaksstottePanel({
+	tittel,
+	undertittel,
+	imgSrc,
+	tekstKomponent,
+	knappKomponent,
+	panelKlasse,
+	detaljer
+}: VedtaksstottePanelProps) {
 	return (
 		<HovedsidePanel className={cls('vedtakstottepanel', panelKlasse)}>
 			<Heading size="small" level="2" className="vedtakstottepanel__tittel">
@@ -28,7 +35,7 @@ export function VedtaksstottePanel(props: VedtaksstottePanelProps) {
 						<Heading size="small" level="3">
 							{undertittel}
 						</Heading>
-						{innsatsgruppe && <Detail textColor="subtle">{innsatsgruppe}</Detail>}
+						{detaljer && <Detail textColor="subtle">{detaljer}</Detail>}
 					</hgroup>
 					<div>{tekstKomponent}</div>
 					{knappKomponent}

--- a/src/component/tidligere-vedtak-liste/tidligere-vedtak-liste.tsx
+++ b/src/component/tidligere-vedtak-liste/tidligere-vedtak-liste.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { BodyShort, Detail } from '@navikt/ds-react';
 import { useViewStore, ViewType } from '../../store/view-store';
 import { sortDatesDesc } from '../../util/date-utils';
 import { OnVedtakClicked, VedtaklistePanel } from '../vedtakliste-panel/vedtakliste-panel';
@@ -7,11 +8,13 @@ import { VedtakListe } from '../vedtak-liste/vedtak-liste';
 import { Vedtak } from '../../api/veilarbvedtaksstotte';
 import { logMetrikk } from '../../util/logger';
 import vedtakBilde from './vedtak.svg';
-import { BodyShort, Detail } from '@navikt/ds-react';
+import { getHovedmalNavn } from '../../util/hovedmal';
 import './tidligere-vedtak-liste.css';
 
 function mapVedtakTilPanel(vedtak: Vedtak, onClick: OnVedtakClicked<Vedtak>, posisjon: number) {
 	const innsatsgruppeTekst = getInnsatsgruppeTekst(vedtak.innsatsgruppe);
+	const hovedmalTekst = getHovedmalNavn(vedtak.hovedmal);
+
 	return (
 		<VedtaklistePanel<Vedtak>
 			name="tidligere-vedtak"
@@ -24,7 +27,7 @@ function mapVedtakTilPanel(vedtak: Vedtak, onClick: OnVedtakClicked<Vedtak>, pos
 			<BodyShort size="small" weight="semibold" className="tidligere-vedtak-panel__innsats--tittel">
 				{innsatsgruppeTekst.tittel}
 			</BodyShort>
-			<Detail textColor="subtle">{innsatsgruppeTekst.undertekst}</Detail>
+			{vedtak.hovedmal && <Detail textColor="subtle">{hovedmalTekst}</Detail>}
 		</VedtaklistePanel>
 	);
 }


### PR DESCRIPTION
https://trello.com/c/5E0qJME9/895-oversiktsside-f%C3%A5-fram-nytt-navn-p%C3%A5-innsatsgruppe-tydeligere
https://trello.com/c/q84qhVLg/929-oversiktsside-vise-hovedm%C3%A5l-for-gjeldende-vedtak-p%C3%A5-oversiktsida
https://trello.com/c/tA3fU75k/934-oversiktsside-vise-hovedm%C3%A5l-for-tidlegare-vedtak-i-staden-for-gamal-innsatsgruppekode

### Før
<img width="600" alt="Screenshot 2025-02-10 at 14 10 34" src="https://github.com/user-attachments/assets/762a7f74-97ae-4fcf-b260-141e68a9dc05" />

(før-biletet er frå lokal køyring, grunna deploy-problem i dev nett no)


### Etter
<img width="600" alt="Screenshot 2025-02-10 at 13 51 01" src="https://github.com/user-attachments/assets/8d16d819-b53f-41cd-8e32-5d0db9509bf3" />
