### PR TITLE
Oppdater visning av fatta vedtak

### DIFF
--- a/src/component/panel/gjeldende-vedtak/gjeldende-vedtak-panel.tsx
+++ b/src/component/panel/gjeldende-vedtak/gjeldende-vedtak-panel.tsx
@@ -1,7 +1,7 @@
 import { Button, Detail } from '@navikt/ds-react';
 import { VedtaksstottePanel } from '../vedtaksstotte/vedtaksstotte-panel';
 import { useViewStore, ViewType } from '../../../store/view-store';
-import { getInnsatsgruppeTekst } from '../../../util/innsatsgruppe';
+import { innsatsgruppeTekst } from '../../../util/innsatsgruppe';
 import fullfortVedtakIcon from './fullfort.svg';
 import { logMetrikk } from '../../../util/logger';
 import { Vedtak } from '../../../api/veilarbvedtaksstotte';
@@ -12,7 +12,6 @@ import './gjeldende-vedtak-panel.css';
 export function GjeldendeVedtakPanel(props: { gjeldendeVedtak: Vedtak }) {
 	const { changeView } = useViewStore();
 	const { id, innsatsgruppe, hovedmal, veilederNavn, vedtakFattet } = props.gjeldendeVedtak;
-	const innsatsgruppeData = getInnsatsgruppeTekst(innsatsgruppe);
 	const hovedmalTekst = hovedmal ? getHovedmalNavn(hovedmal) : undefined;
 
 	const handleVisVedtakClicked = () => {
@@ -23,7 +22,7 @@ export function GjeldendeVedtakPanel(props: { gjeldendeVedtak: Vedtak }) {
 	return (
 		<VedtaksstottePanel
 			tittel="Gjeldende oppfølgingsvedtak"
-			undertittel={innsatsgruppeData.tittel}
+			undertittel={innsatsgruppeTekst[innsatsgruppe]}
 			detaljer={hovedmalTekst}
 			panelKlasse="gjeldende-vedtak-panel"
 			imgSrc={fullfortVedtakIcon}

--- a/src/component/panel/gjeldende-vedtak/gjeldende-vedtak-panel.tsx
+++ b/src/component/panel/gjeldende-vedtak/gjeldende-vedtak-panel.tsx
@@ -2,17 +2,16 @@ import { Button, Detail } from '@navikt/ds-react';
 import { VedtaksstottePanel } from '../vedtaksstotte/vedtaksstotte-panel';
 import { useViewStore, ViewType } from '../../../store/view-store';
 import { innsatsgruppeTekst } from '../../../util/innsatsgruppe';
+import { hovedmalTekst } from '../../../util/hovedmal';
 import fullfortVedtakIcon from './fullfort.svg';
 import { logMetrikk } from '../../../util/logger';
 import { Vedtak } from '../../../api/veilarbvedtaksstotte';
 import { formatDateStr } from '../../../util/date-utils';
-import { getHovedmalNavn } from '../../../util/hovedmal';
 import './gjeldende-vedtak-panel.css';
 
 export function GjeldendeVedtakPanel(props: { gjeldendeVedtak: Vedtak }) {
 	const { changeView } = useViewStore();
 	const { id, innsatsgruppe, hovedmal, veilederNavn, vedtakFattet } = props.gjeldendeVedtak;
-	const hovedmalTekst = hovedmal ? getHovedmalNavn(hovedmal) : undefined;
 
 	const handleVisVedtakClicked = () => {
 		changeView(ViewType.VEDTAK, { vedtakId: id });
@@ -23,7 +22,7 @@ export function GjeldendeVedtakPanel(props: { gjeldendeVedtak: Vedtak }) {
 		<VedtaksstottePanel
 			tittel="Gjeldende oppfølgingsvedtak"
 			undertittel={innsatsgruppeTekst[innsatsgruppe]}
-			detaljer={hovedmalTekst}
+			detaljer={hovedmal ? hovedmalTekst[hovedmal] : undefined}
 			panelKlasse="gjeldende-vedtak-panel"
 			imgSrc={fullfortVedtakIcon}
 			tekstKomponent={

--- a/src/component/skjema-visning/skjema-visning.tsx
+++ b/src/component/skjema-visning/skjema-visning.tsx
@@ -1,10 +1,10 @@
+import { BodyLong, BodyShort, Box, Button, Heading, List, VStack } from '@navikt/ds-react';
 import { useViewStore, ViewType } from '../../store/view-store';
 import { SkjemaVisningHeader } from './header/skjema-visning-header';
 import { formatDateStr } from '../../util/date-utils';
 import { getInnsatsgruppeTekst } from '../../util/innsatsgruppe';
 import { getHovedmalNavn } from '../../util/hovedmal';
 import { Vedtak } from '../../api/veilarbvedtaksstotte';
-import { BodyLong, BodyShort, Box, Button, Heading, Label, List, VStack } from '@navikt/ds-react';
 import './skjema-visning.css';
 
 export function SkjemaVisning(props: { fattetVedtak: Vedtak }) {
@@ -53,16 +53,16 @@ export function SkjemaVisning(props: { fattetVedtak: Vedtak }) {
 				</div>
 
 				<div>
-					<Label size="small" as="p">
-						{innsatsgruppeTekst.tittel}
-					</Label>
-					<BodyShort size="small" spacing>
-						{innsatsgruppeTekst.undertekst}
-					</BodyShort>
+					<Heading size="xsmall" level="2" spacing>
+						Innsatsgruppe
+					</Heading>
+					<BodyShort size="small">{innsatsgruppeTekst.tittel}</BodyShort>
+				</div>
 
-					<Label size="small" as="p">
+				<div>
+					<Heading size="xsmall" level="2" spacing>
 						Hovedmål
-					</Label>
+					</Heading>
 					<BodyShort size="small">{getHovedmalNavn(hovedmal)}</BodyShort>
 				</div>
 

--- a/src/component/skjema-visning/skjema-visning.tsx
+++ b/src/component/skjema-visning/skjema-visning.tsx
@@ -3,7 +3,7 @@ import { useViewStore, ViewType } from '../../store/view-store';
 import { SkjemaVisningHeader } from './header/skjema-visning-header';
 import { formatDateStr } from '../../util/date-utils';
 import { innsatsgruppeTekst } from '../../util/innsatsgruppe';
-import { getHovedmalNavn } from '../../util/hovedmal';
+import { getHovedmalNavnEllerEmdash } from '../../util/hovedmal';
 import { Vedtak } from '../../api/veilarbvedtaksstotte';
 import './skjema-visning.css';
 
@@ -62,7 +62,7 @@ export function SkjemaVisning(props: { fattetVedtak: Vedtak }) {
 					<Heading size="xsmall" level="2" spacing>
 						Hovedmål
 					</Heading>
-					<BodyShort size="small">{getHovedmalNavn(hovedmal)}</BodyShort>
+					<BodyShort size="small">{getHovedmalNavnEllerEmdash(hovedmal)}</BodyShort>
 				</div>
 
 				<div>

--- a/src/component/skjema-visning/skjema-visning.tsx
+++ b/src/component/skjema-visning/skjema-visning.tsx
@@ -4,7 +4,7 @@ import { formatDateStr } from '../../util/date-utils';
 import { getInnsatsgruppeTekst } from '../../util/innsatsgruppe';
 import { getHovedmalNavn } from '../../util/hovedmal';
 import { Vedtak } from '../../api/veilarbvedtaksstotte';
-import { BodyLong, BodyShort, Button, Heading, Label, List, VStack } from '@navikt/ds-react';
+import { BodyLong, BodyShort, Box, Button, Heading, Label, List, VStack } from '@navikt/ds-react';
 import './skjema-visning.css';
 
 export function SkjemaVisning(props: { fattetVedtak: Vedtak }) {
@@ -27,59 +27,68 @@ export function SkjemaVisning(props: { fattetVedtak: Vedtak }) {
 	const fattetAv = `${veilederNavn}, ${oppfolgingsenhetId} ${oppfolgingsenhetNavn}`;
 
 	return (
-		<VStack gap="8" className="skjema-visning">
-			<SkjemaVisningHeader erGjeldende={gjeldende} />
+		<Box
+			background="surface-default"
+			borderColor="border-subtle"
+			borderWidth="1"
+			borderRadius="small"
+			padding="8"
+			marginInline="space-1"
+		>
+			<VStack gap="8" className="skjema-visning">
+				<SkjemaVisningHeader erGjeldende={gjeldende} />
 
-			<div>
-				<BodyShort size="small" spacing>
-					<b>Dato:</b> {formatDateStr(vedtakFattet)}
-				</BodyShort>
-				{beslutterNavn && (
+				<div>
 					<BodyShort size="small" spacing>
-						<b>Kvalitetssikrer:</b> {beslutterNavn}
+						<b>Dato:</b> {formatDateStr(vedtakFattet)}
 					</BodyShort>
-				)}
-				<BodyShort size="small">
-					<b>Fattet av:</b> {fattetAv}
-				</BodyShort>
-			</div>
+					{beslutterNavn && (
+						<BodyShort size="small" spacing>
+							<b>Kvalitetssikrer:</b> {beslutterNavn}
+						</BodyShort>
+					)}
+					<BodyShort size="small">
+						<b>Fattet av:</b> {fattetAv}
+					</BodyShort>
+				</div>
 
-			<div>
-				<Label size="small" as="p">
-					{innsatsgruppeTekst.tittel}
-				</Label>
-				<BodyShort size="small" spacing>
-					{innsatsgruppeTekst.undertekst}
-				</BodyShort>
+				<div>
+					<Label size="small" as="p">
+						{innsatsgruppeTekst.tittel}
+					</Label>
+					<BodyShort size="small" spacing>
+						{innsatsgruppeTekst.undertekst}
+					</BodyShort>
 
-				<Label size="small" as="p">
-					Hovedmål
-				</Label>
-				<BodyShort size="small">{getHovedmalNavn(hovedmal)}</BodyShort>
-			</div>
+					<Label size="small" as="p">
+						Hovedmål
+					</Label>
+					<BodyShort size="small">{getHovedmalNavn(hovedmal)}</BodyShort>
+				</div>
 
-			<div>
-				<Heading size="xsmall" level="2" spacing>
-					Begrunnelse
-				</Heading>
-				<BodyLong size="small" style={{ whiteSpace: 'pre-wrap' }}>
-					{begrunnelse ?? ''}
-				</BodyLong>
-			</div>
+				<div>
+					<Heading size="xsmall" level="2" spacing>
+						Begrunnelse
+					</Heading>
+					<BodyLong size="small" style={{ whiteSpace: 'pre-wrap' }}>
+						{begrunnelse ?? ''}
+					</BodyLong>
+				</div>
 
-			<List size="small" title="Kilder">
-				{opplysninger.map(opplysning => (
-					<List.Item key={opplysning}>{opplysning}</List.Item>
-				))}
-			</List>
+				<List size="small" title="Kilder">
+					{opplysninger.map(opplysning => (
+						<List.Item key={opplysning}>{opplysning}</List.Item>
+					))}
+				</List>
 
-			<Button
-				variant="tertiary"
-				onClick={() => changeView(ViewType.OYBLIKKSBILDE_VISNING, { vedtakId: id })}
-				id="journalfort-info-knapp"
-			>
-				Journalført brukerinformasjon på vedtakstidspunktet
-			</Button>
-		</VStack>
+				<Button
+					variant="tertiary"
+					onClick={() => changeView(ViewType.OYBLIKKSBILDE_VISNING, { vedtakId: id })}
+					id="journalfort-info-knapp"
+				>
+					Journalført brukerinformasjon på vedtakstidspunktet
+				</Button>
+			</VStack>
+		</Box>
 	);
 }

--- a/src/component/skjema-visning/skjema-visning.tsx
+++ b/src/component/skjema-visning/skjema-visning.tsx
@@ -2,7 +2,7 @@ import { BodyLong, BodyShort, Box, Button, Heading, List, VStack } from '@navikt
 import { useViewStore, ViewType } from '../../store/view-store';
 import { SkjemaVisningHeader } from './header/skjema-visning-header';
 import { formatDateStr } from '../../util/date-utils';
-import { getInnsatsgruppeTekst } from '../../util/innsatsgruppe';
+import { innsatsgruppeTekst } from '../../util/innsatsgruppe';
 import { getHovedmalNavn } from '../../util/hovedmal';
 import { Vedtak } from '../../api/veilarbvedtaksstotte';
 import './skjema-visning.css';
@@ -23,7 +23,6 @@ export function SkjemaVisning(props: { fattetVedtak: Vedtak }) {
 		vedtakFattet
 	} = props.fattetVedtak;
 
-	const innsatsgruppeTekst = getInnsatsgruppeTekst(innsatsgruppe);
 	const fattetAv = `${veilederNavn}, ${oppfolgingsenhetId} ${oppfolgingsenhetNavn}`;
 
 	return (
@@ -56,7 +55,7 @@ export function SkjemaVisning(props: { fattetVedtak: Vedtak }) {
 					<Heading size="xsmall" level="2" spacing>
 						Innsatsgruppe
 					</Heading>
-					<BodyShort size="small">{innsatsgruppeTekst.tittel}</BodyShort>
+					<BodyShort size="small">{innsatsgruppeTekst[innsatsgruppe]}</BodyShort>
 				</div>
 
 				<div>

--- a/src/component/tidligere-vedtak-liste/tidligere-vedtak-liste.tsx
+++ b/src/component/tidligere-vedtak-liste/tidligere-vedtak-liste.tsx
@@ -3,7 +3,7 @@ import { BodyShort, Detail } from '@navikt/ds-react';
 import { useViewStore, ViewType } from '../../store/view-store';
 import { sortDatesDesc } from '../../util/date-utils';
 import { OnVedtakClicked, VedtaklistePanel } from '../vedtakliste-panel/vedtakliste-panel';
-import { getInnsatsgruppeTekst } from '../../util/innsatsgruppe';
+import { innsatsgruppeTekst } from '../../util/innsatsgruppe';
 import { VedtakListe } from '../vedtak-liste/vedtak-liste';
 import { Vedtak } from '../../api/veilarbvedtaksstotte';
 import { logMetrikk } from '../../util/logger';
@@ -12,7 +12,6 @@ import { getHovedmalNavn } from '../../util/hovedmal';
 import './tidligere-vedtak-liste.css';
 
 function mapVedtakTilPanel(vedtak: Vedtak, onClick: OnVedtakClicked<Vedtak>, posisjon: number) {
-	const innsatsgruppeTekst = getInnsatsgruppeTekst(vedtak.innsatsgruppe);
 	const hovedmalTekst = getHovedmalNavn(vedtak.hovedmal);
 
 	return (
@@ -25,7 +24,7 @@ function mapVedtakTilPanel(vedtak: Vedtak, onClick: OnVedtakClicked<Vedtak>, pos
 			ikon={vedtakBilde}
 		>
 			<BodyShort size="small" weight="semibold" className="tidligere-vedtak-panel__innsats--tittel">
-				{innsatsgruppeTekst.tittel}
+				{innsatsgruppeTekst[vedtak.innsatsgruppe]}
 			</BodyShort>
 			{vedtak.hovedmal && <Detail textColor="subtle">{hovedmalTekst}</Detail>}
 		</VedtaklistePanel>

--- a/src/component/tidligere-vedtak-liste/tidligere-vedtak-liste.tsx
+++ b/src/component/tidligere-vedtak-liste/tidligere-vedtak-liste.tsx
@@ -7,13 +7,11 @@ import { innsatsgruppeTekst } from '../../util/innsatsgruppe';
 import { VedtakListe } from '../vedtak-liste/vedtak-liste';
 import { Vedtak } from '../../api/veilarbvedtaksstotte';
 import { logMetrikk } from '../../util/logger';
+import { hovedmalTekst } from '../../util/hovedmal';
 import vedtakBilde from './vedtak.svg';
-import { getHovedmalNavn } from '../../util/hovedmal';
 import './tidligere-vedtak-liste.css';
 
 function mapVedtakTilPanel(vedtak: Vedtak, onClick: OnVedtakClicked<Vedtak>, posisjon: number) {
-	const hovedmalTekst = getHovedmalNavn(vedtak.hovedmal);
-
 	return (
 		<VedtaklistePanel<Vedtak>
 			name="tidligere-vedtak"
@@ -26,7 +24,7 @@ function mapVedtakTilPanel(vedtak: Vedtak, onClick: OnVedtakClicked<Vedtak>, pos
 			<BodyShort size="small" weight="semibold" className="tidligere-vedtak-panel__innsats--tittel">
 				{innsatsgruppeTekst[vedtak.innsatsgruppe]}
 			</BodyShort>
-			{vedtak.hovedmal && <Detail textColor="subtle">{hovedmalTekst}</Detail>}
+			{vedtak.hovedmal && <Detail textColor="subtle">{hovedmalTekst[vedtak.hovedmal]}</Detail>}
 		</VedtaklistePanel>
 	);
 }

--- a/src/page/utkast/skjema-section/hovedmal/hovedmal.tsx
+++ b/src/page/utkast/skjema-section/hovedmal/hovedmal.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from 'react';
+import { Alert, Radio, RadioGroup } from '@navikt/ds-react';
+import { ArbeidssokerPeriode } from '@navikt/arbeidssokerregisteret-utils';
 import FeltHeader from '../felt-header/felt-header';
-import { alleHovedmal } from '../../../../util/hovedmal';
+import { hovedmalTekst } from '../../../../util/hovedmal';
 import { useSkjemaStore } from '../../../../store/skjema-store';
 import { useAppStore } from '../../../../store/app-store';
 import { HovedmalType, InnsatsgruppeType } from '../../../../api/veilarbvedtaksstotte';
 import { swallowEnterKeyPress } from '../../../../util';
-import { ArbeidssokerPeriode } from '@navikt/arbeidssokerregisteret-utils';
 import { fetchAktivArbeidssokerperiode } from '../../../../api/veilarbperson';
-import { Alert, Radio, RadioGroup } from '@navikt/ds-react';
 import './hovedmal.css';
 
 function Hovedmal() {
@@ -45,15 +45,15 @@ function Hovedmal() {
 								arbeidssøker.
 							</Alert>
 						)}
-						{alleHovedmal.map(mal => (
+						{Object.values(HovedmalType).map(hovedmaltype => (
 							<Radio
-								key={mal.value}
-								value={mal.value}
+								key={hovedmaltype}
+								value={hovedmaltype}
 								onKeyDown={swallowEnterKeyPress}
 								// Hvis brukeren ikke har en aktiv arbeidssøkerperiode, skal ikke hovedmål "Skaffe arbeid" kunne velges
-								disabled={!arbeidssoekerperiode && mal.value === HovedmalType.SKAFFE_ARBEID}
+								disabled={!arbeidssoekerperiode && hovedmaltype === HovedmalType.SKAFFE_ARBEID}
 							>
-								{mal.label}
+								{hovedmalTekst[hovedmaltype]}
 							</Radio>
 						))}
 					</>

--- a/src/page/utkast/skjema-section/innsatsgruppe/innsatsgruppe.tsx
+++ b/src/page/utkast/skjema-section/innsatsgruppe/innsatsgruppe.tsx
@@ -6,7 +6,7 @@ import { InnsatsgruppeType } from '../../../../api/veilarbvedtaksstotte';
 import { OrNothing } from '../../../../util/type/ornothing';
 import { ModalType, useModalStore } from '../../../../store/modal-store';
 import { useDataStore } from '../../../../store/data-store';
-import { erStandard, erVarigEllerGradertVarig, innsatsgruppeTekster } from '../../../../util/innsatsgruppe';
+import { erStandard, erVarigEllerGradertVarig, innsatsgruppeTekst } from '../../../../util/innsatsgruppe';
 import { useSkjemaStore } from '../../../../store/skjema-store';
 import { useDialogSection } from '../../../../store/dialog-section-store';
 import { Alert, Radio, RadioGroup } from '@navikt/ds-react';
@@ -87,9 +87,9 @@ function InnsatsgruppeRadioButtons(props: InnsatsgruppeRadioProps) {
 			value={props.innsatsgruppe}
 			error={errors.innsatsgruppe}
 		>
-			{innsatsgruppeTekster.map(innsatsgruppetekst => (
-				<Radio key={innsatsgruppetekst.value} value={innsatsgruppetekst.value} onKeyDown={swallowEnterKeyPress}>
-					{innsatsgruppetekst.tittel}
+			{Object.values(InnsatsgruppeType).map(innsatsgruppetype => (
+				<Radio key={innsatsgruppetype} value={innsatsgruppetype} onKeyDown={swallowEnterKeyPress}>
+					{innsatsgruppeTekst[innsatsgruppetype]}
 				</Radio>
 			))}
 		</RadioGroup>

--- a/src/page/utkast/skjema-section/les-skjema-section.tsx
+++ b/src/page/utkast/skjema-section/les-skjema-section.tsx
@@ -12,7 +12,7 @@ import { fetchUtkast } from '../../../api/veilarbvedtaksstotte/utkast';
 import { BeslutterProsessStatus, Utkast } from '../../../api/veilarbvedtaksstotte';
 import { OrNothing } from '../../../util/type/ornothing';
 import { hentFattedeVedtak } from '../../../api/veilarbvedtaksstotte/vedtak';
-import { getInnsatsgruppeTekst } from '../../../util/innsatsgruppe';
+import { innsatsgruppeTekst } from '../../../util/innsatsgruppe';
 import { getHovedmalNavn } from '../../../util/hovedmal';
 import { MalformData, MalformType } from '../../../api/veilarbperson';
 import { BodyLong, BodyShort, List } from '@navikt/ds-react';
@@ -138,7 +138,7 @@ export function LesSkjemaSection() {
 
 			<div className="innsatsgruppe-felt">
 				<FeltHeader tittel="Innsatsgruppe" />
-				{innsatsgruppe && <BodyShort size="small">{getInnsatsgruppeTekst(innsatsgruppe).tittel}</BodyShort>}
+				{innsatsgruppe && <BodyShort size="small">{innsatsgruppeTekst[innsatsgruppe]}</BodyShort>}
 			</div>
 
 			<div className="hovedmal-felt">

--- a/src/page/utkast/skjema-section/les-skjema-section.tsx
+++ b/src/page/utkast/skjema-section/les-skjema-section.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
-import { VarselType } from '../../../component/varsel/varsel-type';
 import isEqual from 'lodash.isequal';
+import { BodyLong, BodyShort, List } from '@navikt/ds-react';
+import { VarselType } from '../../../component/varsel/varsel-type';
 import FeltHeader from './felt-header/felt-header';
 import { useAppStore } from '../../../store/app-store';
 import { useViewStore, ViewType } from '../../../store/view-store';
@@ -13,11 +14,10 @@ import { BeslutterProsessStatus, Utkast } from '../../../api/veilarbvedtaksstott
 import { OrNothing } from '../../../util/type/ornothing';
 import { hentFattedeVedtak } from '../../../api/veilarbvedtaksstotte/vedtak';
 import { innsatsgruppeTekst } from '../../../util/innsatsgruppe';
-import { getHovedmalNavn } from '../../../util/hovedmal';
+import { getHovedmalNavnEllerEmdash } from '../../../util/hovedmal';
 import { MalformData, MalformType } from '../../../api/veilarbperson';
-import { BodyLong, BodyShort, List } from '@navikt/ds-react';
-import './skjema-section.less';
 import { standardForArbeidsrettetOppfolgingsLenke } from '../../../util/constants';
+import './skjema-section.less';
 
 const TEN_SECONDS = 10000;
 
@@ -143,7 +143,7 @@ export function LesSkjemaSection() {
 
 			<div className="hovedmal-felt">
 				<FeltHeader tittel="Hovedmål" />
-				<BodyShort size="small">{getHovedmalNavn(hovedmal)}</BodyShort>
+				<BodyShort size="small">{getHovedmalNavnEllerEmdash(hovedmal)}</BodyShort>
 			</div>
 		</div>
 	);

--- a/src/util/hovedmal.ts
+++ b/src/util/hovedmal.ts
@@ -1,19 +1,16 @@
 import { OrNothing } from './type/ornothing';
-import { EMDASH } from './index';
 import { HovedmalType } from '../api/veilarbvedtaksstotte';
+import { EMDASH } from './index';
 
-export const getHovedmalNavn = (hovedmal: OrNothing<HovedmalType>) => {
-	const hovedmalobjekt = alleHovedmal.find(h => h.value === hovedmal);
-	return (hovedmalobjekt && hovedmalobjekt.label) || EMDASH;
+export const getHovedmalNavnEllerEmdash = (hovedmal: OrNothing<HovedmalType>) => {
+	if (hovedmal) {
+		return hovedmalTekst[hovedmal];
+	}
+
+	return EMDASH;
 };
 
-export const alleHovedmal = [
-	{
-		label: 'Skaffe arbeid',
-		value: HovedmalType.SKAFFE_ARBEID
-	},
-	{
-		label: 'Beholde arbeid',
-		value: HovedmalType.BEHOLDE_ARBEID
-	}
-];
+export const hovedmalTekst: { [key in HovedmalType]: string } = {
+	[HovedmalType.SKAFFE_ARBEID]: 'Skaffe arbeid',
+	[HovedmalType.BEHOLDE_ARBEID]: 'Beholde arbeid'
+};

--- a/src/util/innsatsgruppe.ts
+++ b/src/util/innsatsgruppe.ts
@@ -1,10 +1,6 @@
 import { OrNothing } from './type/ornothing';
 import { InnsatsgruppeType } from '../api/veilarbvedtaksstotte';
 
-export const getInnsatsgruppeTekst = (innsatsgruppeType: InnsatsgruppeType) => {
-	return innsatsgruppeTekster.find(elem => elem.value === innsatsgruppeType) as InnsatsgruppeTekst;
-};
-
 export const erStandard = (innsatsgruppe: OrNothing<InnsatsgruppeType>): boolean => {
 	return innsatsgruppe === InnsatsgruppeType.STANDARD_INNSATS;
 };
@@ -16,30 +12,10 @@ export const erVarigEllerGradertVarig = (innsatsgruppe: OrNothing<InnsatsgruppeT
 	);
 };
 
-export interface InnsatsgruppeTekst {
-	tittel: string;
-	value: InnsatsgruppeType;
-}
-
-export const innsatsgruppeTekster: InnsatsgruppeTekst[] = [
-	{
-		tittel: 'Gode muligheter',
-		value: InnsatsgruppeType.STANDARD_INNSATS
-	},
-	{
-		tittel: 'Trenger veiledning',
-		value: InnsatsgruppeType.SITUASJONSBESTEMT_INNSATS
-	},
-	{
-		tittel: 'Trenger veiledning, nedsatt arbeidsevne',
-		value: InnsatsgruppeType.SPESIELT_TILPASSET_INNSATS
-	},
-	{
-		tittel: 'Jobbe delvis',
-		value: InnsatsgruppeType.GRADERT_VARIG_TILPASSET_INNSATS
-	},
-	{
-		tittel: 'Liten mulighet til å jobbe',
-		value: InnsatsgruppeType.VARIG_TILPASSET_INNSATS
-	}
-];
+export const innsatsgruppeTekst: { [key in InnsatsgruppeType]: string } = {
+	[InnsatsgruppeType.STANDARD_INNSATS]: 'Gode muligheter',
+	[InnsatsgruppeType.SITUASJONSBESTEMT_INNSATS]: 'Trenger veiledning',
+	[InnsatsgruppeType.SPESIELT_TILPASSET_INNSATS]: 'Trenger veiledning, nedsatt arbeidsevne',
+	[InnsatsgruppeType.GRADERT_VARIG_TILPASSET_INNSATS]: 'Jobbe delvis',
+	[InnsatsgruppeType.VARIG_TILPASSET_INNSATS]: 'Liten mulighet til å jobbe'
+};

--- a/src/util/innsatsgruppe.ts
+++ b/src/util/innsatsgruppe.ts
@@ -18,34 +18,28 @@ export const erVarigEllerGradertVarig = (innsatsgruppe: OrNothing<InnsatsgruppeT
 
 export interface InnsatsgruppeTekst {
 	tittel: string;
-	undertekst: string;
 	value: InnsatsgruppeType;
 }
 
 export const innsatsgruppeTekster: InnsatsgruppeTekst[] = [
 	{
 		tittel: 'Gode muligheter',
-		undertekst: 'STANDARD INNSATS',
 		value: InnsatsgruppeType.STANDARD_INNSATS
 	},
 	{
 		tittel: 'Trenger veiledning',
-		undertekst: 'SITUASJONSBESTEMT INNSATS',
 		value: InnsatsgruppeType.SITUASJONSBESTEMT_INNSATS
 	},
 	{
 		tittel: 'Trenger veiledning, nedsatt arbeidsevne',
-		undertekst: 'SPESIELT TILPASSET INNSATS',
 		value: InnsatsgruppeType.SPESIELT_TILPASSET_INNSATS
 	},
 	{
 		tittel: 'Jobbe delvis',
-		undertekst: 'DELVIS, VARIG TILPASSET INNSATS',
 		value: InnsatsgruppeType.GRADERT_VARIG_TILPASSET_INNSATS
 	},
 	{
 		tittel: 'Liten mulighet til å jobbe',
-		undertekst: 'VARIG TILPASSET INNSATS',
 		value: InnsatsgruppeType.VARIG_TILPASSET_INNSATS
 	}
 ];


### PR DESCRIPTION
... og rydd litt i kodestrukturen til tekstar for innsatsgruppe/hovedmål.


- Kvit bakgrunn rundt vedtak
- "Innsatsgruppe" og "Hovedmål" er no overskrifter på nivå 2
- Ikkje vis gamle innsatsgruppenamn


Resultat:
![image](https://github.com/user-attachments/assets/27f56590-64e1-43f4-b727-0cb367790541)

