### PR TITLE
Funksjonsbrytar for å gjere Skaffe arbeid valgbar utan arbeidssøkerperiode

### DIFF
--- a/src/api/obo-unleash.ts
+++ b/src/api/obo-unleash.ts
@@ -2,11 +2,16 @@ import { AxiosPromise } from 'axios';
 import { axiosInstance } from './utils';
 
 export const PRELANSERING_INFO_OM_LOSNING_TOGGLE = 'veilarbvedtaksstottefs.prelansering-info-om-losning';
-
-export const ALL_TOGGLES = [PRELANSERING_INFO_OM_LOSNING_TOGGLE];
+export const HOVEDMAL_SKAFFE_ARBEID_UAVHENGIG_AV_ARBEIDSSOKERPERIODE =
+	'veilarbvedtaksstotte.gjorHovedmalSkaffeArbeidTilgjengeligForBrukereUtenArbeidssokerperiode';
+export const ALL_TOGGLES = [
+	PRELANSERING_INFO_OM_LOSNING_TOGGLE,
+	HOVEDMAL_SKAFFE_ARBEID_UAVHENGIG_AV_ARBEIDSSOKERPERIODE
+];
 
 export interface FeatureToggles {
 	[PRELANSERING_INFO_OM_LOSNING_TOGGLE]: boolean;
+	[HOVEDMAL_SKAFFE_ARBEID_UAVHENGIG_AV_ARBEIDSSOKERPERIODE]: boolean;
 }
 
 export function fetchFeaturesToggles(): AxiosPromise<FeatureToggles> {

--- a/src/mock/api-data.ts
+++ b/src/mock/api-data.ts
@@ -1,7 +1,11 @@
 import OppfolgingData from '../api/veilarboppfolging';
 import TilgangTilBrukersKontor from '../util/type/tilgang-til-brukers-kontor';
 import { MalformData, MalformType, Navn } from '../api/veilarbperson';
-import { FeatureToggles, PRELANSERING_INFO_OM_LOSNING_TOGGLE } from '../api/obo-unleash';
+import {
+	FeatureToggles,
+	HOVEDMAL_SKAFFE_ARBEID_UAVHENGIG_AV_ARBEIDSSOKERPERIODE,
+	PRELANSERING_INFO_OM_LOSNING_TOGGLE
+} from '../api/obo-unleash';
 import { Veileder } from '../api/veilarbveileder';
 import { enhetId, enhetNavn, veileder1, veileder2, veileder3 } from './data';
 import { DialogMelding, SystemMelding } from '../api/veilarbvedtaksstotte/meldinger';
@@ -53,7 +57,8 @@ const arbeidssokerperiode = {
 } as unknown as ArbeidssokerPeriode;
 
 const features: FeatureToggles = {
-	[PRELANSERING_INFO_OM_LOSNING_TOGGLE]: true
+	[PRELANSERING_INFO_OM_LOSNING_TOGGLE]: true,
+	[HOVEDMAL_SKAFFE_ARBEID_UAVHENGIG_AV_ARBEIDSSOKERPERIODE]: false
 };
 
 let innloggetVeileder: Veileder = {

--- a/src/page/utkast/skjema-section/hovedmal/hovedmal.tsx
+++ b/src/page/utkast/skjema-section/hovedmal/hovedmal.tsx
@@ -8,6 +8,8 @@ import { useAppStore } from '../../../../store/app-store';
 import { HovedmalType, InnsatsgruppeType } from '../../../../api/veilarbvedtaksstotte';
 import { swallowEnterKeyPress } from '../../../../util';
 import { fetchAktivArbeidssokerperiode } from '../../../../api/veilarbperson';
+import { useDataStore } from '../../../../store/data-store';
+import { HOVEDMAL_SKAFFE_ARBEID_UAVHENGIG_AV_ARBEIDSSOKERPERIODE } from '../../../../api/obo-unleash';
 import './hovedmal.css';
 
 function Hovedmal() {
@@ -16,7 +18,11 @@ function Hovedmal() {
 	const [arbeidssoekerperiode, setArbeidssoekerperiode] = useState<ArbeidssokerPeriode | null>(null);
 	const { fnr } = useAppStore();
 
-	const skaffeArbeidErIkkeValgbar = !arbeidssoekerperiode;
+	const { features } = useDataStore();
+	const skaffeArbeidUavhengigAvArbeidssokerperiode =
+		features[HOVEDMAL_SKAFFE_ARBEID_UAVHENGIG_AV_ARBEIDSSOKERPERIODE];
+
+	const skaffeArbeidErIkkeValgbar = !skaffeArbeidUavhengigAvArbeidssokerperiode && !arbeidssoekerperiode;
 
 	useEffect(() => {
 		if (!arbeidssoekerperiode) {
@@ -52,7 +58,7 @@ function Hovedmal() {
 								key={hovedmaltype}
 								value={hovedmaltype}
 								onKeyDown={swallowEnterKeyPress}
-								// Hvis brukeren ikke har en aktiv arbeidssøkerperiode, skal ikke hovedmål "Skaffe arbeid" kunne velges
+								// Hvis brukeren ikke har en aktiv arbeidssøkerperiode (og feature-toggle er av), skal ikke hovedmål "Skaffe arbeid" kunne velges
 								disabled={skaffeArbeidErIkkeValgbar && hovedmaltype === HovedmalType.SKAFFE_ARBEID}
 							>
 								{hovedmalTekst[hovedmaltype]}

--- a/src/page/utkast/skjema-section/hovedmal/hovedmal.tsx
+++ b/src/page/utkast/skjema-section/hovedmal/hovedmal.tsx
@@ -16,6 +16,8 @@ function Hovedmal() {
 	const [arbeidssoekerperiode, setArbeidssoekerperiode] = useState<ArbeidssokerPeriode | null>(null);
 	const { fnr } = useAppStore();
 
+	const skaffeArbeidErIkkeValgbar = !arbeidssoekerperiode;
+
 	useEffect(() => {
 		if (!arbeidssoekerperiode) {
 			fetchAktivArbeidssokerperiode(fnr).then(response => setArbeidssoekerperiode(response.data));
@@ -39,7 +41,7 @@ function Hovedmal() {
 					</span>
 				) : (
 					<>
-						{!arbeidssoekerperiode && (
+						{skaffeArbeidErIkkeValgbar && (
 							<Alert size="small" variant="warning" inline>
 								Hovedmål <i>skaffe arbeid</i> kan ikke velges fordi personen ikke er registrert som
 								arbeidssøker.
@@ -51,7 +53,7 @@ function Hovedmal() {
 								value={hovedmaltype}
 								onKeyDown={swallowEnterKeyPress}
 								// Hvis brukeren ikke har en aktiv arbeidssøkerperiode, skal ikke hovedmål "Skaffe arbeid" kunne velges
-								disabled={!arbeidssoekerperiode && hovedmaltype === HovedmalType.SKAFFE_ARBEID}
+								disabled={skaffeArbeidErIkkeValgbar && hovedmaltype === HovedmalType.SKAFFE_ARBEID}
 							>
 								{hovedmalTekst[hovedmaltype]}
 							</Radio>


### PR DESCRIPTION
Om toggle er på: 
- Alltid la Skaffe arbeid vere valbar, sjølv om brukar manglar arbeidssøkerperiode.

Om toggle er av: 
- Skaffe arbeid er kun valbar for brukarar som har arbeidssøkarperiode.