### PR TITLE
Legg tilbake funksjon da den innførte feil

### DIFF
--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -11,7 +11,7 @@ export function isAnyLoading(...fetchers: { loading: boolean }[]): boolean {
 }
 
 export function isAnyLoadingOrNotStarted(
-	...fetchers: { data?: any; error?: any; loading: boolean; status?: any }[]
+	...fetchers: { data?: any; error?: any; loading: boolean; status?: number }[]
 ): boolean {
 	return fetchers.some(f => f.loading || (!f.error && !f.data && f.status !== 204));
 }

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -10,6 +10,12 @@ export function isAnyLoading(...fetchers: { loading: boolean }[]): boolean {
 	return fetchers.some(f => f.loading);
 }
 
+export function isAnyLoadingOrNotStarted(
+	...fetchers: { data?: any; error?: any; loading: boolean; status?: any }[]
+): boolean {
+	return fetchers.some(f => f.loading || (!f.error && !f.data && f.status !== 204));
+}
+
 export function hasAnyFailed(...fetchers: { error?: AxiosError }[]): boolean {
 	return fetchers.some(f => f.error);
 }

--- a/src/component/data-fetcher.tsx
+++ b/src/component/data-fetcher.tsx
@@ -10,7 +10,7 @@ import { fetchOppfolging } from '../api/veilarboppfolging';
 import { fetchAktivArbeidssokerperiode, fetchMalform, fetchNavn } from '../api/veilarbperson';
 import { fetchUtkast } from '../api/veilarbvedtaksstotte/utkast';
 import { fetchInnloggetVeileder } from '../api/veilarbveileder';
-import { ifResponseHasData, hasAnyFailed, isAnyLoading } from '../api/utils';
+import { ifResponseHasData, hasAnyFailed, isAnyLoadingOrNotStarted } from '../api/utils';
 import { IkkeKontaktMedBaksystemFeilmelding } from './feilmelding/ikke-kontakt-med-baksystem-feilmelding';
 
 export function DataFetcher(props: { fnr: string; children: any }) {
@@ -73,7 +73,7 @@ export function DataFetcher(props: { fnr: string; children: any }) {
 	}, [innloggetVeilederFetcher, utkastFetcher]);
 
 	if (
-		isAnyLoading(
+		isAnyLoadingOrNotStarted(
 			fattedeVedtakFetcher,
 			oppfolgingFetcher,
 			malformFetcher,


### PR DESCRIPTION
Prøvde å fjerne andre ledd fra "f.loading || (!f.error && !f.data);" for å få med tomme responser med 204. Da ville ikke overgangen fra kvalitetsikring til en person laste, men en hvit side. Legger det derfor tilbake igjen, men med en sjekk på om koden ikke er 204. 